### PR TITLE
Fix charts on card

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -248,12 +248,7 @@ position: relative;
 // dashboard small card ----------------------------------
 
 .card-dashboard {
-    a {
-        text-decoration: none;
-      }
-    a:hover {
-      text-decoration: none;
-    }
+
 }
 .chart-card {
   height: 10em;
@@ -261,4 +256,47 @@ position: relative;
 }
 .card-sm-font {
   color: $font-color;
+}
+
+// grid --------------
+
+.stock-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 8px;
+}
+
+// Smallest device
+@media (min-width: 100px) and (max-width: 575px) {
+  .stock-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+// Small devices (landscape phones, 576px and up)
+@media (min-width: 576px) {
+  .stock-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+// Medium devices (tablets, 768px and up)
+@media (min-width: 768px) {
+  .stock-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+// Large devices (desktops, 992px and up)
+@media (min-width: 992px) {
+  .stock-cards {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+// Extra large devices (large desktops, 1200px and up)
+@media (min-width: 1200px) {
+  .stock-cards {
+    grid-template-columns: 1fr 1fr;
+  }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   def dashboard
     @user = current_user
     @purchases = current_user.purchases
-    @products = @user.products
+    @products = @user.products.uniq
     @total_valuation = @products.inject(0) { |result, product| result + calc_valuation(product) }
     @product_valuation_pair = @products.map { |product| [product, calc_valuation(product)] }
     @product_price_pair = @products.map { |product| [product, get_product_price(product)] }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     @purchases = current_user.purchases
     @products = @user.products.uniq
     @total_valuation = @products.inject(0) { |result, product| result + calc_valuation(product) }
-    @product_valuation_pair = @products.map { |product| [product, calc_valuation(product)] }
+    # @product_valuation_pair = @products.map { |product| [product, calc_valuation(product)] }
     @product_price_pair = @products.map { |product| [product, get_product_price(product)] }
     authorize @user
   end

--- a/app/views/users/_small-card.html.erb
+++ b/app/views/users/_small-card.html.erb
@@ -6,7 +6,7 @@
     <h3 class="font-weight-bold"><%= price.round(2) %></h3>
   </div>
   <div class="stock-card-chart">
-    <%= line_chart charts_stock_price_history_path(product), points: false, xmin: "2020-12-01", xmax: "2021-03-01", height: "100%"  %>
+    <%= line_chart charts_stock_price_history_path(product), points: false, xmin: Date.today - 30, xmax: Date.today, height: "100%"  %>
   </div>
 </div>
 <% end %>

--- a/app/views/users/_small-card.html.erb
+++ b/app/views/users/_small-card.html.erb
@@ -1,11 +1,11 @@
 <%= link_to product_path(product), style: "text-decoration: none;" do %>
-<div class="my-2 d-flex flex-row justify-content-between card card-dashboard">
-  <div class="text-white col-3">
-    <h5 class="card-title pl-2 pt-1 m-0"><%= product.name %></h5>
-    <p class="card-subtitle mb-2 text-muted pl-2" ><%= product.ticker %></p>
-    <h3 class="font-weight-bold pl-2"><%= price.round(2) %></h3>
+<div class="m-2 p-2 d-flex flex-row justify-content-between card card-dashboard">
+  <div class="text-white p-1">
+    <h5 class="m-0"><%= product.name %></h5>
+    <p class="mb-2 text-muted" ><%= product.ticker %></p>
+    <h3 class="font-weight-bold"><%= price.round(2) %></h3>
   </div>
-  <div class="col-6">
+  <div class="stock-card-chart">
     <%= line_chart charts_stock_price_history_path(product), points: false, xmin: "2020-12-01", xmax: "2021-03-01", height: "100%"  %>
   </div>
 </div>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -20,7 +20,7 @@
     </div>
   </div>
 </div>
-<div class="container ml-0 mt-3">
+<div class="mt-3 col-8 stock-cards">
   <% @product_price_pair.each do |product_price_pair| %>
   <%= render 'users/small-card', product: product_price_pair[0], price: product_price_pair[1] %>
   <% end %>


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-03-08 at 9 34 05" src="https://user-images.githubusercontent.com/46629248/110261530-f3438100-7ff3-11eb-8544-b0265306f39c.png">
Now the product card works like the le wagon UI kit grid.
It still looks funny when the size of the window is squeezed and the My Stocks card will grow so we gotta fix that. 